### PR TITLE
fix AER to ENU

### DIFF
--- a/types.go
+++ b/types.go
@@ -143,27 +143,25 @@ type ENU struct {
 
 // ENU will translate the AER angular vector into 3D space as an ENU.
 func (aed AER) ENU() ENU {
-	var (
-		sinTheta = math.Sin(aed.Elevation.Radians().F64())
-		cosTheta = math.Cos(aed.Elevation.Radians().F64())
-		sinPhi   = math.Sin(aed.Azimuth.Radians().F64())
-		cosPhi   = math.Cos(aed.Azimuth.Radians().F64())
-	)
+	var r = aed.Range * Meters(math.Cos(aed.Elevation.Radians().F64()))
 
 	return ENU{
-		East:  aed.Range * Meters(sinPhi*cosTheta),
-		North: aed.Range * Meters(cosPhi*sinTheta),
-		Up:    aed.Range * Meters(sinTheta),
+		East:  r * Meters(math.Sin(aed.Azimuth.Radians().F64())),
+		North: r * Meters(math.Cos(aed.Azimuth.Radians().F64())),
+		Up:    aed.Range * Meters(math.Sin(aed.Elevation.Radians().F64())),
 	}
 }
 
 // AER will convert the 3D ENU point, and return it as an angular AER vector.
 func (enu ENU) AER() AER {
-	var r = Meters(math.Sqrt((enu.East*enu.East + enu.North*enu.North).F64()))
+	var (
+		r   = Meters(math.Sqrt((enu.East*enu.East + enu.North*enu.North).F64()))
+		tau = math.Pi * 2
+	)
 
 	return AER{
-		Azimuth:   Degrees(math.Atan2(enu.East.F64(), enu.North.F64())),
-		Elevation: Degrees(math.Atan2(enu.Up.F64(), r.F64())),
+		Azimuth:   Radians(math.Mod(math.Atan2(enu.East.F64(), enu.North.F64()), tau)).Degrees(),
+		Elevation: Radians(math.Atan2(enu.Up.F64(), r.F64())).Degrees(),
 		Range:     Meters(math.Sqrt((r*r + enu.Up*enu.Up).F64())),
 	}
 }

--- a/types.go
+++ b/types.go
@@ -159,16 +159,12 @@ func (aed AER) ENU() ENU {
 
 // AER will convert the 3D ENU point, and return it as an angular AER vector.
 func (enu ENU) AER() AER {
-	var (
-		d  = Meters(math.Sqrt((enu.East*enu.East + enu.North*enu.North + enu.Up*enu.Up).F64()))
-		el = Radians(math.Acos((enu.Up / d).F64()))
-		az = Radians(math.Atan2(enu.North.F64(), enu.East.F64()))
-	)
+	var r = Meters(math.Sqrt((enu.East*enu.East + enu.North*enu.North).F64()))
 
 	return AER{
-		Azimuth:   az.Degrees(),
-		Elevation: el.Degrees(),
-		Range:     d,
+		Azimuth:   Degrees(math.Atan2(enu.East.F64(), enu.North.F64())),
+		Elevation: Degrees(math.Atan2(enu.Up.F64(), r.F64())),
+		Range:     Meters(math.Sqrt((r*r + enu.Up*enu.Up).F64())),
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -151,9 +151,9 @@ func (aed AER) ENU() ENU {
 	)
 
 	return ENU{
-		East:  aed.Range * Meters(sinTheta*cosPhi),
-		North: aed.Range * Meters(sinTheta*sinPhi),
-		Up:    aed.Range * Meters(cosTheta),
+		East:  aed.Range * Meters(sinPhi*cosTheta),
+		North: aed.Range * Meters(cosPhi*sinTheta),
+		Up:    aed.Range * Meters(sinTheta),
 	}
 }
 


### PR DESCRIPTION
sine and cosine were reversed. Should be as follows:

```go
geo.ENU{
    East:  geo.Meters(r * math.Sin(az.F64())),
    North: geo.Meters(r * math.Cos(az.F64())),
    Up:    geo.Meters(aer.Range.F64() * math.Sin(el.F64())),
}
```